### PR TITLE
Fix Quarkus 3 compatibility issues in ShedLock providers

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-shedlock-provider-jdbc.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-shedlock-provider-jdbc.adoc
@@ -11,13 +11,13 @@ h|[[quarkus-shedlock-provider-jdbc_section_quarkus-shedlock-jdbc]] [.section-nam
 h|Type
 h|Default
 
-a| [[quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-enable-table-creation]] [.property-path]##link:#quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-enable-table-creation[`quarkus.shedlock.jdbc.enable-table-creation`]##
+a| [[quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-enable-table-creation]] [.property-path]##link:#quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-enable-table-creation[`+++quarkus.shedlock.jdbc.enable-table-creation+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.jdbc.enable-table-creation+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.shedlock.jdbc."datasource-name".enable-table-creation`
+`+++quarkus.shedlock.jdbc."datasource-name".enable-table-creation+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.jdbc."datasource-name".enable-table-creation+++[]
 endif::add-copy-button-to-config-props[]
@@ -35,15 +35,15 @@ Environment variable: `+++QUARKUS_SHEDLOCK_JDBC_ENABLE_TABLE_CREATION+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`true`
+|`+++true+++`
 
-a| [[quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-table-name]] [.property-path]##link:#quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-table-name[`quarkus.shedlock.jdbc.table-name`]##
+a| [[quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-table-name]] [.property-path]##link:#quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-table-name[`+++quarkus.shedlock.jdbc.table-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.jdbc.table-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.shedlock.jdbc."datasource-name".table-name`
+`+++quarkus.shedlock.jdbc."datasource-name".table-name+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.jdbc."datasource-name".table-name+++[]
 endif::add-copy-button-to-config-props[]
@@ -61,7 +61,7 @@ Environment variable: `+++QUARKUS_SHEDLOCK_JDBC_TABLE_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`shedLock`
+|`+++shedLock+++`
 
 
 |===

--- a/docs/modules/ROOT/pages/includes/quarkus-shedlock-provider-jdbc_quarkus.shedlock.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-shedlock-provider-jdbc_quarkus.shedlock.adoc
@@ -11,13 +11,13 @@ h|[[quarkus-shedlock-provider-jdbc_section_quarkus-shedlock-jdbc]] [.section-nam
 h|Type
 h|Default
 
-a| [[quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-enable-table-creation]] [.property-path]##link:#quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-enable-table-creation[`quarkus.shedlock.jdbc.enable-table-creation`]##
+a| [[quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-enable-table-creation]] [.property-path]##link:#quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-enable-table-creation[`+++quarkus.shedlock.jdbc.enable-table-creation+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.jdbc.enable-table-creation+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.shedlock.jdbc."datasource-name".enable-table-creation`
+`+++quarkus.shedlock.jdbc."datasource-name".enable-table-creation+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.jdbc."datasource-name".enable-table-creation+++[]
 endif::add-copy-button-to-config-props[]
@@ -35,15 +35,15 @@ Environment variable: `+++QUARKUS_SHEDLOCK_JDBC_ENABLE_TABLE_CREATION+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`true`
+|`+++true+++`
 
-a| [[quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-table-name]] [.property-path]##link:#quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-table-name[`quarkus.shedlock.jdbc.table-name`]##
+a| [[quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-table-name]] [.property-path]##link:#quarkus-shedlock-provider-jdbc_quarkus-shedlock-jdbc-table-name[`+++quarkus.shedlock.jdbc.table-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.jdbc.table-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.shedlock.jdbc."datasource-name".table-name`
+`+++quarkus.shedlock.jdbc."datasource-name".table-name+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.jdbc."datasource-name".table-name+++[]
 endif::add-copy-button-to-config-props[]
@@ -61,7 +61,7 @@ Environment variable: `+++QUARKUS_SHEDLOCK_JDBC_TABLE_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`shedLock`
+|`+++shedLock+++`
 
 
 |===

--- a/docs/modules/ROOT/pages/includes/quarkus-shedlock-provider-mongo-reactive.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-shedlock-provider-mongo-reactive.adoc
@@ -11,13 +11,13 @@ h|[[quarkus-shedlock-provider-mongo-reactive_section_quarkus-shedlock-mongo-reac
 h|Type
 h|Default
 
-a| [[quarkus-shedlock-provider-mongo-reactive_quarkus-shedlock-mongo-reactive-database-name]] [.property-path]##link:#quarkus-shedlock-provider-mongo-reactive_quarkus-shedlock-mongo-reactive-database-name[`quarkus.shedlock.mongo-reactive.database-name`]##
+a| [[quarkus-shedlock-provider-mongo-reactive_quarkus-shedlock-mongo-reactive-database-name]] [.property-path]##link:#quarkus-shedlock-provider-mongo-reactive_quarkus-shedlock-mongo-reactive-database-name[`+++quarkus.shedlock.mongo-reactive.database-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.mongo-reactive.database-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.shedlock.mongo-reactive."mongoclient-name".database-name`
+`+++quarkus.shedlock.mongo-reactive."mongoclient-name".database-name+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.mongo-reactive."mongoclient-name".database-name+++[]
 endif::add-copy-button-to-config-props[]
@@ -35,7 +35,7 @@ Environment variable: `+++QUARKUS_SHEDLOCK_MONGO_REACTIVE_DATABASE_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`shedLock`
+|`+++shedLock+++`
 
 
 |===

--- a/docs/modules/ROOT/pages/includes/quarkus-shedlock-provider-mongo-reactive_quarkus.shedlock.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-shedlock-provider-mongo-reactive_quarkus.shedlock.adoc
@@ -11,13 +11,13 @@ h|[[quarkus-shedlock-provider-mongo-reactive_section_quarkus-shedlock-mongo-reac
 h|Type
 h|Default
 
-a| [[quarkus-shedlock-provider-mongo-reactive_quarkus-shedlock-mongo-reactive-database-name]] [.property-path]##link:#quarkus-shedlock-provider-mongo-reactive_quarkus-shedlock-mongo-reactive-database-name[`quarkus.shedlock.mongo-reactive.database-name`]##
+a| [[quarkus-shedlock-provider-mongo-reactive_quarkus-shedlock-mongo-reactive-database-name]] [.property-path]##link:#quarkus-shedlock-provider-mongo-reactive_quarkus-shedlock-mongo-reactive-database-name[`+++quarkus.shedlock.mongo-reactive.database-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.mongo-reactive.database-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.shedlock.mongo-reactive."mongoclient-name".database-name`
+`+++quarkus.shedlock.mongo-reactive."mongoclient-name".database-name+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.mongo-reactive."mongoclient-name".database-name+++[]
 endif::add-copy-button-to-config-props[]
@@ -35,7 +35,7 @@ Environment variable: `+++QUARKUS_SHEDLOCK_MONGO_REACTIVE_DATABASE_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`shedLock`
+|`+++shedLock+++`
 
 
 |===

--- a/docs/modules/ROOT/pages/includes/quarkus-shedlock-provider-mongo.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-shedlock-provider-mongo.adoc
@@ -11,13 +11,13 @@ h|[[quarkus-shedlock-provider-mongo_section_quarkus-shedlock-mongo]] [.section-n
 h|Type
 h|Default
 
-a| [[quarkus-shedlock-provider-mongo_quarkus-shedlock-mongo-database-name]] [.property-path]##link:#quarkus-shedlock-provider-mongo_quarkus-shedlock-mongo-database-name[`quarkus.shedlock.mongo.database-name`]##
+a| [[quarkus-shedlock-provider-mongo_quarkus-shedlock-mongo-database-name]] [.property-path]##link:#quarkus-shedlock-provider-mongo_quarkus-shedlock-mongo-database-name[`+++quarkus.shedlock.mongo.database-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.mongo.database-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.shedlock.mongo."mongoclient-name".database-name`
+`+++quarkus.shedlock.mongo."mongoclient-name".database-name+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.mongo."mongoclient-name".database-name+++[]
 endif::add-copy-button-to-config-props[]
@@ -35,7 +35,7 @@ Environment variable: `+++QUARKUS_SHEDLOCK_MONGO_DATABASE_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`shedLock`
+|`+++shedLock+++`
 
 
 |===

--- a/docs/modules/ROOT/pages/includes/quarkus-shedlock-provider-mongo_quarkus.shedlock.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-shedlock-provider-mongo_quarkus.shedlock.adoc
@@ -11,13 +11,13 @@ h|[[quarkus-shedlock-provider-mongo_section_quarkus-shedlock-mongo]] [.section-n
 h|Type
 h|Default
 
-a| [[quarkus-shedlock-provider-mongo_quarkus-shedlock-mongo-database-name]] [.property-path]##link:#quarkus-shedlock-provider-mongo_quarkus-shedlock-mongo-database-name[`quarkus.shedlock.mongo.database-name`]##
+a| [[quarkus-shedlock-provider-mongo_quarkus-shedlock-mongo-database-name]] [.property-path]##link:#quarkus-shedlock-provider-mongo_quarkus-shedlock-mongo-database-name[`+++quarkus.shedlock.mongo.database-name+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.mongo.database-name+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`quarkus.shedlock.mongo."mongoclient-name".database-name`
+`+++quarkus.shedlock.mongo."mongoclient-name".database-name+++`
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.mongo."mongoclient-name".database-name+++[]
 endif::add-copy-button-to-config-props[]
@@ -35,7 +35,7 @@ Environment variable: `+++QUARKUS_SHEDLOCK_MONGO_DATABASE_NAME+++`
 endif::add-copy-button-to-env-var[]
 --
 |string
-|`shedLock`
+|`+++shedLock+++`
 
 
 |===

--- a/docs/modules/ROOT/pages/includes/quarkus-shedlock.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-shedlock.adoc
@@ -7,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a| [[quarkus-shedlock_quarkus-shedlock-defaults-lock-at-most-for]] [.property-path]##link:#quarkus-shedlock_quarkus-shedlock-defaults-lock-at-most-for[`quarkus.shedlock.defaults-lock-at-most-for`]##
+a| [[quarkus-shedlock_quarkus-shedlock-defaults-lock-at-most-for]] [.property-path]##link:#quarkus-shedlock_quarkus-shedlock-defaults-lock-at-most-for[`+++quarkus.shedlock.defaults-lock-at-most-for+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.defaults-lock-at-most-for+++[]
 endif::add-copy-button-to-config-props[]
@@ -28,7 +28,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a| [[quarkus-shedlock_quarkus-shedlock-defaults-lock-at-least-for]] [.property-path]##link:#quarkus-shedlock_quarkus-shedlock-defaults-lock-at-least-for[`quarkus.shedlock.defaults-lock-at-least-for`]##
+a| [[quarkus-shedlock_quarkus-shedlock-defaults-lock-at-least-for]] [.property-path]##link:#quarkus-shedlock_quarkus-shedlock-defaults-lock-at-least-for[`+++quarkus.shedlock.defaults-lock-at-least-for+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.defaults-lock-at-least-for+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-shedlock_quarkus.shedlock.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-shedlock_quarkus.shedlock.adoc
@@ -7,7 +7,7 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
-a| [[quarkus-shedlock_quarkus-shedlock-defaults-lock-at-most-for]] [.property-path]##link:#quarkus-shedlock_quarkus-shedlock-defaults-lock-at-most-for[`quarkus.shedlock.defaults-lock-at-most-for`]##
+a| [[quarkus-shedlock_quarkus-shedlock-defaults-lock-at-most-for]] [.property-path]##link:#quarkus-shedlock_quarkus-shedlock-defaults-lock-at-most-for[`+++quarkus.shedlock.defaults-lock-at-most-for+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.defaults-lock-at-most-for+++[]
 endif::add-copy-button-to-config-props[]
@@ -28,7 +28,7 @@ endif::add-copy-button-to-env-var[]
 |string
 |required icon:exclamation-circle[title=Configuration property is required]
 
-a| [[quarkus-shedlock_quarkus-shedlock-defaults-lock-at-least-for]] [.property-path]##link:#quarkus-shedlock_quarkus-shedlock-defaults-lock-at-least-for[`quarkus.shedlock.defaults-lock-at-least-for`]##
+a| [[quarkus-shedlock_quarkus-shedlock-defaults-lock-at-least-for]] [.property-path]##link:#quarkus-shedlock_quarkus-shedlock-defaults-lock-at-least-for[`+++quarkus.shedlock.defaults-lock-at-least-for+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.shedlock.defaults-lock-at-least-for+++[]
 endif::add-copy-button-to-config-props[]

--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus.version>3.24.2</quarkus.version>
-        <shedlock.version>7.0.0</shedlock.version>
+        <quarkus.version>3.34.3</quarkus.version>
+        <shedlock.version>7.7.0</shedlock.version>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/providers/inmemory/deployment/src/main/java/io/quarkiverse/shedlock/providers/inmemory/deployment/InMemorySchedulerLockProcessor.java
+++ b/providers/inmemory/deployment/src/main/java/io/quarkiverse/shedlock/providers/inmemory/deployment/InMemorySchedulerLockProcessor.java
@@ -42,14 +42,14 @@ public class InMemorySchedulerLockProcessor {
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
     SyntheticBeanBuildItem registerInMemorySchedulerLockExecutor(
-            final ShedLockConfiguration shedLockConfiguration,
             final InMemorySchedulerLockExecutorRecorder inMemorySchedulerLockExecutorRecorder) {
         return SyntheticBeanBuildItem.configure(SchedulerLockExecutor.class)
                 .scope(Singleton.class)
-                .createWith(inMemorySchedulerLockExecutorRecorder.schedulerLockExecutorSupplier(shedLockConfiguration))
+                .createWith(inMemorySchedulerLockExecutorRecorder.schedulerLockExecutorSupplier())
                 .addQualifier(AnnotationInstance.builder(InMemorySchedulerLockExecutor.class).build())
-                .addInjectionPoint(ClassType.create(DotName.createSimple(DefaultInMemoryLockProvider.class)))
+                .addInjectionPoint(ClassType.create(DotName.createSimple(ShedLockConfiguration.class)))
                 .addInjectionPoint(ClassType.create(DotName.createSimple(InstantProvider.class)))
+                .addInjectionPoint(ClassType.create(DotName.createSimple(DefaultInMemoryLockProvider.class)))
                 .unremovable()
                 .setRuntimeInit()
                 .done();

--- a/providers/inmemory/runtime/src/main/java/io/quarkiverse/shedlock/providers/inmemory/runtime/InMemorySchedulerLockExecutorRecorder.java
+++ b/providers/inmemory/runtime/src/main/java/io/quarkiverse/shedlock/providers/inmemory/runtime/InMemorySchedulerLockExecutorRecorder.java
@@ -11,13 +11,12 @@ import io.quarkus.runtime.annotations.Recorder;
 @Recorder
 public class InMemorySchedulerLockExecutorRecorder {
 
-    public Function<SyntheticCreationalContext<SchedulerLockExecutor>, SchedulerLockExecutor> schedulerLockExecutorSupplier(
-            final ShedLockConfiguration shedLockConfiguration) {
+    public Function<SyntheticCreationalContext<SchedulerLockExecutor>, SchedulerLockExecutor> schedulerLockExecutorSupplier() {
         return new Function<SyntheticCreationalContext<SchedulerLockExecutor>, SchedulerLockExecutor>() {
             @Override
             public SchedulerLockExecutor apply(final SyntheticCreationalContext<SchedulerLockExecutor> context) {
                 return new SchedulerLockExecutor(
-                        shedLockConfiguration,
+                        context.getInjectedReference(ShedLockConfiguration.class),
                         context.getInjectedReference(InstantProvider.class),
                         context.getInjectedReference(DefaultInMemoryLockProvider.class));
             }

--- a/providers/jdbc/deployment/src/main/java/io/quarkiverse/shedlock/providers/jdbc/deployment/JdbcSchedulerLockProcessor.java
+++ b/providers/jdbc/deployment/src/main/java/io/quarkiverse/shedlock/providers/jdbc/deployment/JdbcSchedulerLockProcessor.java
@@ -100,8 +100,6 @@ public class JdbcSchedulerLockProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     List<SyntheticBeanBuildItem> registerJdbcSchedulerLockExecutors(
             final CombinedIndexBuildItem combinedIndexBuildItem,
-            final ShedLockConfiguration shedLockConfiguration,
-            final JdbcConfig jdbcConfig,
             final JdbcSchedulerLockExecutorRecorder jdbcSchedulerLockExecutorRecorder) {
         final IndexView index = combinedIndexBuildItem.getComputingIndex();
         final Set<Qualifier> qualifiers = combinedIndexBuildItem.getIndex()
@@ -116,11 +114,11 @@ public class JdbcSchedulerLockProcessor {
         return qualifiers.stream()
                 .map(qualifier -> SyntheticBeanBuildItem.configure(SchedulerLockExecutor.class)
                         .scope(Singleton.class)
-                        .createWith(jdbcSchedulerLockExecutorRecorder.schedulerLockExecutorSupplier(shedLockConfiguration,
-                                jdbcConfig,
-                                qualifier.dataSourceName))
+                        .createWith(jdbcSchedulerLockExecutorRecorder.schedulerLockExecutorSupplier(qualifier.dataSourceName))
                         .addQualifier(qualifier.toQualifier())
+                        .addInjectionPoint(ClassType.create(DotName.createSimple(ShedLockConfiguration.class)))
                         .addInjectionPoint(ClassType.create(DotName.createSimple(InstantProvider.class)))
+                        .addInjectionPoint(ClassType.create(DotName.createSimple(JdbcConfig.class)))
                         .unremovable()
                         .setRuntimeInit()
                         .done())

--- a/providers/jdbc/runtime/src/main/java/io/quarkiverse/shedlock/providers/jdbc/runtime/JdbcSchedulerLockExecutorRecorder.java
+++ b/providers/jdbc/runtime/src/main/java/io/quarkiverse/shedlock/providers/jdbc/runtime/JdbcSchedulerLockExecutorRecorder.java
@@ -21,12 +21,13 @@ import net.javacrumbs.shedlock.provider.jdbc.JdbcLockProvider;
 public class JdbcSchedulerLockExecutorRecorder {
 
     public Function<SyntheticCreationalContext<SchedulerLockExecutor>, SchedulerLockExecutor> schedulerLockExecutorSupplier(
-            final ShedLockConfiguration shedLockConfiguration,
-            final JdbcConfig jdbcConfig,
             final String dataSourceName) {
         return new Function<SyntheticCreationalContext<SchedulerLockExecutor>, SchedulerLockExecutor>() {
             @Override
             public SchedulerLockExecutor apply(final SyntheticCreationalContext<SchedulerLockExecutor> context) {
+
+                JdbcConfig jdbcConfig = context.getInjectedReference(JdbcConfig.class);
+
                 final String tableName = Optional.ofNullable(jdbcConfig.dataSources().get(dataSourceName))
                         .map(JdbcConfig.DataSourceConfig::tableName)
                         .orElse(SchedulerLockInterceptorBase.SHED_LOCK);
@@ -36,7 +37,7 @@ public class JdbcSchedulerLockExecutorRecorder {
                                         : new DataSource.DataSourceLiteral(dataSourceName))
                         .get();
                 return new SchedulerLockExecutor(
-                        shedLockConfiguration,
+                        context.getInjectedReference(ShedLockConfiguration.class),
                         context.getInjectedReference(InstantProvider.class),
                         new JdbcLockProvider(agroalDataSource, tableName));
             }

--- a/providers/mongo-reactive/deployment/src/main/java/io/quarkiverse/shedlock/providers/mongo/reactive/deployment/deployment/MongoReactiveSchedulerLockProcessor.java
+++ b/providers/mongo-reactive/deployment/src/main/java/io/quarkiverse/shedlock/providers/mongo/reactive/deployment/deployment/MongoReactiveSchedulerLockProcessor.java
@@ -47,8 +47,6 @@ public class MongoReactiveSchedulerLockProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     List<SyntheticBeanBuildItem> registerMongoReactiveSchedulerLockExecutors(
             final CombinedIndexBuildItem combinedIndexBuildItem,
-            final ShedLockConfiguration shedLockConfiguration,
-            final MongoReactiveConfig mongoReactiveConfig,
             final MongoReactiveSchedulerLockExecutorRecorder mongoReactiveSchedulerLockExecutorRecorder) {
         final IndexView index = combinedIndexBuildItem.getComputingIndex();
         final Set<Qualifier> qualifiers = combinedIndexBuildItem.getIndex()
@@ -64,11 +62,12 @@ public class MongoReactiveSchedulerLockProcessor {
                 .map(qualifier -> SyntheticBeanBuildItem.configure(SchedulerLockExecutor.class)
                         .scope(Singleton.class)
                         .createWith(
-                                mongoReactiveSchedulerLockExecutorRecorder.schedulerLockExecutorSupplier(shedLockConfiguration,
-                                        mongoReactiveConfig,
-                                        qualifier.mongoClientName))
+                                mongoReactiveSchedulerLockExecutorRecorder
+                                        .schedulerLockExecutorSupplier(qualifier.mongoClientName))
                         .addQualifier(qualifier.toQualifier())
                         .addInjectionPoint(ClassType.create(DotName.createSimple(InstantProvider.class)))
+                        .addInjectionPoint(ClassType.create(DotName.createSimple(ShedLockConfiguration.class)))
+                        .addInjectionPoint(ClassType.create(DotName.createSimple(MongoReactiveConfig.class)))
                         .unremovable()
                         .setRuntimeInit()
                         .done())

--- a/providers/mongo-reactive/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/reactive/runtime/runtime/MongoReactiveConfig.java
+++ b/providers/mongo-reactive/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/reactive/runtime/runtime/MongoReactiveConfig.java
@@ -3,7 +3,6 @@ package io.quarkiverse.shedlock.providers.mongo.reactive.runtime.runtime;
 import java.util.Map;
 
 import io.quarkiverse.shedlock.common.runtime.SchedulerLockInterceptorBase;
-import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 import io.quarkus.runtime.annotations.*;
 import io.smallrye.config.*;
 
@@ -17,7 +16,7 @@ public interface MongoReactiveConfig {
     @ConfigDocMapKey("mongoclient-name")
     @WithParentName
     @WithDefaults
-    @WithUnnamedKey(MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME)
+    @WithUnnamedKey(io.quarkus.mongodb.runtime.MongoConfig.DEFAULT_REACTIVE_CLIENT_NAME)
     Map<String, MongoClientConfig> mongoclients();
 
     @ConfigGroup

--- a/providers/mongo-reactive/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/reactive/runtime/runtime/MongoReactiveSchedulerLock.java
+++ b/providers/mongo-reactive/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/reactive/runtime/runtime/MongoReactiveSchedulerLock.java
@@ -6,7 +6,6 @@ import jakarta.enterprise.util.Nonbinding;
 import jakarta.interceptor.InterceptorBinding;
 
 import io.quarkiverse.shedlock.common.runtime.LockDuration;
-import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 
 @InterceptorBinding
 @Retention(RetentionPolicy.RUNTIME)
@@ -14,7 +13,7 @@ import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 @Inherited
 public @interface MongoReactiveSchedulerLock {
     @Nonbinding
-    String mongoClientName() default MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME;
+    String mongoClientName() default io.quarkus.mongodb.runtime.MongoConfig.DEFAULT_REACTIVE_CLIENT_NAME;
 
     @Nonbinding
     LockDuration lockDuration() default @LockDuration();

--- a/providers/mongo-reactive/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/reactive/runtime/runtime/MongoReactiveSchedulerLockExecutor.java
+++ b/providers/mongo-reactive/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/reactive/runtime/runtime/MongoReactiveSchedulerLockExecutor.java
@@ -5,10 +5,8 @@ import java.lang.annotation.RetentionPolicy;
 
 import jakarta.inject.Qualifier;
 
-import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
-
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MongoReactiveSchedulerLockExecutor {
-    String mongoClientName() default MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME;
+    String mongoClientName() default io.quarkus.mongodb.runtime.MongoConfig.DEFAULT_REACTIVE_CLIENT_NAME;
 }

--- a/providers/mongo-reactive/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/reactive/runtime/runtime/MongoReactiveSchedulerLockExecutorRecorder.java
+++ b/providers/mongo-reactive/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/reactive/runtime/runtime/MongoReactiveSchedulerLockExecutorRecorder.java
@@ -14,7 +14,6 @@ import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.mongodb.MongoClientName;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.mongodb.reactive.ReactiveMongoDatabase;
-import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 import io.quarkus.runtime.annotations.Recorder;
 import net.javacrumbs.shedlock.provider.mongo.reactivestreams.ReactiveStreamsMongoLockProvider;
 
@@ -22,15 +21,17 @@ import net.javacrumbs.shedlock.provider.mongo.reactivestreams.ReactiveStreamsMon
 public class MongoReactiveSchedulerLockExecutorRecorder {
 
     public Function<SyntheticCreationalContext<SchedulerLockExecutor>, SchedulerLockExecutor> schedulerLockExecutorSupplier(
-            final ShedLockConfiguration shedLockConfiguration,
-            final MongoReactiveConfig mongoReactiveConfig,
             final String mongoClientName) {
         return new Function<SyntheticCreationalContext<SchedulerLockExecutor>, SchedulerLockExecutor>() {
             @Override
             public SchedulerLockExecutor apply(final SyntheticCreationalContext<SchedulerLockExecutor> context) {
+
+                MongoReactiveConfig mongoReactiveConfig = context.getInjectedReference(MongoReactiveConfig.class);
+
                 final ReactiveMongoClient mongoClient = Arc.container()
                         .select(ReactiveMongoClient.class,
-                                MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME.equals(mongoClientName) ? new Default.Literal()
+                                io.quarkus.mongodb.runtime.MongoConfig.DEFAULT_REACTIVE_CLIENT_NAME.equals(mongoClientName)
+                                        ? new Default.Literal()
                                         : new MongoClientName.Literal(mongoClientName))
                         .get();
                 final String databaseName = Optional.ofNullable(mongoReactiveConfig.mongoclients().get(mongoClientName))
@@ -38,7 +39,7 @@ public class MongoReactiveSchedulerLockExecutorRecorder {
                         .orElse(SchedulerLockInterceptorBase.SHED_LOCK);
                 final ReactiveMongoDatabase database = mongoClient.getDatabase(databaseName);
                 return new SchedulerLockExecutor(
-                        shedLockConfiguration,
+                        context.getInjectedReference(ShedLockConfiguration.class),
                         context.getInjectedReference(InstantProvider.class),
                         new ReactiveStreamsMongoLockProvider(database.unwrap()));
             }

--- a/providers/mongo-reactive/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/reactive/runtime/runtime/MongoReactiveSchedulerLockInterceptor.java
+++ b/providers/mongo-reactive/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/reactive/runtime/runtime/MongoReactiveSchedulerLockInterceptor.java
@@ -18,7 +18,6 @@ import io.quarkus.arc.Arc;
 import io.quarkus.mongodb.MongoClientName;
 import io.quarkus.mongodb.reactive.ReactiveMongoClient;
 import io.quarkus.mongodb.reactive.ReactiveMongoDatabase;
-import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.mongo.reactivestreams.ReactiveStreamsMongoLockProvider;
 
@@ -46,7 +45,8 @@ public class MongoReactiveSchedulerLockInterceptor extends SchedulerLockIntercep
         final String mongoClientName = method.getAnnotation(MongoReactiveSchedulerLock.class).mongoClientName();
         final ReactiveMongoClient mongoClient = Arc.container()
                 .select(ReactiveMongoClient.class,
-                        MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME.equals(mongoClientName) ? new Default.Literal()
+                        io.quarkus.mongodb.runtime.MongoConfig.DEFAULT_REACTIVE_CLIENT_NAME.equals(mongoClientName)
+                                ? new Default.Literal()
                                 : new MongoClientName.Literal(mongoClientName))
                 .get();
         final String databaseName = Optional.ofNullable(mongoReactiveConfig.mongoclients().get(mongoClientName))

--- a/providers/mongo/deployment/src/main/java/io/quarkiverse/shedlock/providers/mongo/deployment/MongoSchedulerLockProcessor.java
+++ b/providers/mongo/deployment/src/main/java/io/quarkiverse/shedlock/providers/mongo/deployment/MongoSchedulerLockProcessor.java
@@ -50,8 +50,6 @@ public class MongoSchedulerLockProcessor {
     @Record(ExecutionTime.RUNTIME_INIT)
     List<SyntheticBeanBuildItem> registerMongoSchedulerLockExecutors(
             final CombinedIndexBuildItem combinedIndexBuildItem,
-            final ShedLockConfiguration shedLockConfiguration,
-            final MongoConfig mongoConfig,
             final MongoSchedulerLockExecutorRecorder mongoSchedulerLockExecutorRecorder) {
         final IndexView index = combinedIndexBuildItem.getComputingIndex();
         final Set<Qualifier> qualifiers = combinedIndexBuildItem.getIndex()
@@ -66,11 +64,11 @@ public class MongoSchedulerLockProcessor {
         return qualifiers.stream()
                 .map(qualifier -> SyntheticBeanBuildItem.configure(SchedulerLockExecutor.class)
                         .scope(Singleton.class)
-                        .createWith(mongoSchedulerLockExecutorRecorder.schedulerLockExecutorSupplier(shedLockConfiguration,
-                                mongoConfig,
-                                qualifier.mongoClientName))
+                        .createWith(mongoSchedulerLockExecutorRecorder.schedulerLockExecutorSupplier(qualifier.mongoClientName))
                         .addQualifier(qualifier.toQualifier())
+                        .addInjectionPoint(ClassType.create(DotName.createSimple(ShedLockConfiguration.class)))
                         .addInjectionPoint(ClassType.create(DotName.createSimple(InstantProvider.class)))
+                        .addInjectionPoint(ClassType.create(DotName.createSimple(MongoConfig.class)))
                         .unremovable()
                         .setRuntimeInit()
                         .done())

--- a/providers/mongo/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/runtime/MongoConfig.java
+++ b/providers/mongo/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/runtime/MongoConfig.java
@@ -3,7 +3,6 @@ package io.quarkiverse.shedlock.providers.mongo.runtime;
 import java.util.Map;
 
 import io.quarkiverse.shedlock.common.runtime.SchedulerLockInterceptorBase;
-import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 import io.quarkus.runtime.annotations.*;
 import io.smallrye.config.*;
 
@@ -17,7 +16,7 @@ public interface MongoConfig {
     @ConfigDocMapKey("mongoclient-name")
     @WithParentName
     @WithDefaults
-    @WithUnnamedKey(MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME)
+    @WithUnnamedKey(io.quarkus.mongodb.runtime.MongoConfig.DEFAULT_CLIENT_NAME)
     Map<String, MongoClientConfig> mongoclients();
 
     @ConfigGroup

--- a/providers/mongo/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/runtime/MongoSchedulerLock.java
+++ b/providers/mongo/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/runtime/MongoSchedulerLock.java
@@ -6,7 +6,6 @@ import jakarta.enterprise.util.Nonbinding;
 import jakarta.interceptor.InterceptorBinding;
 
 import io.quarkiverse.shedlock.common.runtime.LockDuration;
-import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 
 @InterceptorBinding
 @Retention(RetentionPolicy.RUNTIME)
@@ -14,7 +13,7 @@ import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 @Inherited
 public @interface MongoSchedulerLock {
     @Nonbinding
-    String mongoClientName() default MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME;
+    String mongoClientName() default io.quarkus.mongodb.runtime.MongoConfig.DEFAULT_CLIENT_NAME;
 
     @Nonbinding
     LockDuration lockDuration() default @LockDuration();

--- a/providers/mongo/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/runtime/MongoSchedulerLockExecutor.java
+++ b/providers/mongo/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/runtime/MongoSchedulerLockExecutor.java
@@ -5,10 +5,8 @@ import java.lang.annotation.RetentionPolicy;
 
 import jakarta.inject.Qualifier;
 
-import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
-
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)
 public @interface MongoSchedulerLockExecutor {
-    String mongoClientName() default MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME;
+    String mongoClientName() default io.quarkus.mongodb.runtime.MongoConfig.DEFAULT_CLIENT_NAME;
 }

--- a/providers/mongo/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/runtime/MongoSchedulerLockExecutorRecorder.java
+++ b/providers/mongo/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/runtime/MongoSchedulerLockExecutorRecorder.java
@@ -15,7 +15,6 @@ import io.quarkiverse.shedlock.common.runtime.ShedLockConfiguration;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.mongodb.MongoClientName;
-import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 import io.quarkus.runtime.annotations.Recorder;
 import net.javacrumbs.shedlock.provider.mongo.MongoLockProvider;
 
@@ -23,15 +22,17 @@ import net.javacrumbs.shedlock.provider.mongo.MongoLockProvider;
 public class MongoSchedulerLockExecutorRecorder {
 
     public Function<SyntheticCreationalContext<SchedulerLockExecutor>, SchedulerLockExecutor> schedulerLockExecutorSupplier(
-            final ShedLockConfiguration shedLockConfiguration,
-            final MongoConfig mongoConfig,
             final String mongoClientName) {
         return new Function<SyntheticCreationalContext<SchedulerLockExecutor>, SchedulerLockExecutor>() {
             @Override
             public SchedulerLockExecutor apply(final SyntheticCreationalContext<SchedulerLockExecutor> context) {
+
+                MongoConfig mongoConfig = context.getInjectedReference(MongoConfig.class);
+
                 final MongoClient mongoClient = Arc.container()
                         .select(MongoClient.class,
-                                MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME.equals(mongoClientName) ? new Default.Literal()
+                                io.quarkus.mongodb.runtime.MongoConfig.DEFAULT_CLIENT_NAME.equals(mongoClientName)
+                                        ? new Default.Literal()
                                         : new MongoClientName.Literal(mongoClientName))
                         .get();
                 final String databaseName = Optional.ofNullable(mongoConfig.mongoclients().get(mongoClientName))
@@ -39,7 +40,7 @@ public class MongoSchedulerLockExecutorRecorder {
                         .orElse(SchedulerLockInterceptorBase.SHED_LOCK);
                 final MongoDatabase database = mongoClient.getDatabase(databaseName);
                 return new SchedulerLockExecutor(
-                        shedLockConfiguration,
+                        context.getInjectedReference(ShedLockConfiguration.class),
                         context.getInjectedReference(InstantProvider.class),
                         new MongoLockProvider(database));
             }

--- a/providers/mongo/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/runtime/MongoSchedulerLockInterceptor.java
+++ b/providers/mongo/runtime/src/main/java/io/quarkiverse/shedlock/providers/mongo/runtime/MongoSchedulerLockInterceptor.java
@@ -19,7 +19,6 @@ import io.quarkiverse.shedlock.common.runtime.SchedulerLockInterceptorBase;
 import io.quarkiverse.shedlock.common.runtime.ShedLockConfiguration;
 import io.quarkus.arc.Arc;
 import io.quarkus.mongodb.MongoClientName;
-import io.quarkus.mongodb.runtime.MongoClientBeanUtil;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.mongo.MongoLockProvider;
 
@@ -47,7 +46,8 @@ public class MongoSchedulerLockInterceptor extends SchedulerLockInterceptorBase 
         final String mongoClientName = method.getAnnotation(MongoSchedulerLock.class).mongoClientName();
         final MongoClient mongoClient = Arc.container()
                 .select(MongoClient.class,
-                        MongoClientBeanUtil.DEFAULT_MONGOCLIENT_NAME.equals(mongoClientName) ? new Default.Literal()
+                        io.quarkus.mongodb.runtime.MongoConfig.DEFAULT_CLIENT_NAME.equals(mongoClientName)
+                                ? new Default.Literal()
                                 : new MongoClientName.Literal(mongoClientName))
                 .get();
         final String databaseName = Optional.ofNullable(mongoConfig.mongoclients().get(mongoClientName))


### PR DESCRIPTION
## Summary

This PR updates the Quarkus ShedLock providers to be compatible with Quarkus 3.x.

## Changes

- Fixed build-time vs runtime configuration violations in Quarkus build steps
- Replaced deprecated `RuntimeValue` usage patterns
- Migrated synthetic bean injection to Quarkus 3 compliant API
- Updated Mongo, JDBC, and InMemory providers to align with current Quarkus extension model
- Fixed missing/removed Mongo client constants in newer Quarkus versions

## Motivation

The project fails to compile/run on modern Quarkus versions due to API changes in:
- MongoDB extension
- Synthetic bean injection model
- Build step runtime constraints

## Testing

- Built with Quarkus 3.x (3.34.3)
- Verified test suite runs via Maven/Surefire